### PR TITLE
Use correct key to lookup rrsets in zone

### DIFF
--- a/models.py
+++ b/models.py
@@ -93,7 +93,7 @@ class Zone(Model):
 
     @property
     def rrsets(self):
-        return {RRset(**rrset) for rrset in self.data['records']}
+        return {RRset(**rrset) for rrset in self.data['rrsets']}
 
     def update_rrsets(self, rrsets, delete=False):
         rrsets_changes = []


### PR DESCRIPTION
As per [PowerDNS API docs](https://doc.powerdns.com/authoritative/http-api/zone.html#zone) The Resource Record Sets of a Zone are listed in the `rrsets` key of the `zone` object.

This client tries to source them from the `records` key. which fails with the following error:
```
$ ./pdns -c conf.toml show-rrsets example.nz.
Traceback (most recent call last):
  File "./pdns", line 243, in <module>
    pdns_client.run()
  File "./pdns", line 77, in run
    module.run()
  File "./commands/rrset.py", line 54, in run
    getattr(self, (self.args.action).replace('-', '_'))()
  File "./commands/rrset.py", line 61, in show_rrsets
    for rrset in sorted([rrset for rrset in zone.rrsets if rrset.name == zone.data['name']],
  File ./models.py", line 96, in rrsets
    return {RRset(**rrset) for rrset in self.data['records']}
KeyError: 'records'
```

